### PR TITLE
allow building against latest LV2

### DIFF
--- a/gui/gx_reversedelay_x11ui.c
+++ b/gui/gx_reversedelay_x11ui.c
@@ -210,7 +210,7 @@ cairo_surface_t *cairo_image_surface_create_from_stream (gx_reversedelayUI* ui, 
 ----------------------------------------------------------------------*/
 
 // init the xwindow and return the LV2UI handle
-static LV2UI_Handle instantiate(const struct _LV2UI_Descriptor * descriptor,
+static LV2UI_Handle instantiate(const struct LV2UI_Descriptor * descriptor,
 			const char * plugin_uri, const char * bundle_path,
 			LV2UI_Write_Function write_function,
 			LV2UI_Controller controller, LV2UI_Widget * widget,
@@ -1138,4 +1138,3 @@ const LV2UI_Descriptor* lv2ui_descriptor(uint32_t index) {
 		return NULL;
 	}
 }
-


### PR DESCRIPTION
Disclaimer: not a programmer here, so I might be totally out of cleverness.
That said I already see people hacking that on other project lately.
Building current GIT master 7bf3bc0 without that patch fails.
With this patch, build successes.
The resulting built plugin seems to work here.